### PR TITLE
implement timeout parameter and socket destroy

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ class HttpProxy {
             agent: this.agent,
             protocol: config.protocol,
             hostname: config.hostname,
-            port: config.port
+            port: config.port,
+            timeout: config.timeout
         };
     }
 
@@ -82,6 +83,7 @@ class HttpProxy {
             });
 
             proxyReq.once("timeout", () => {
+                proxyReq.destroy();
                 next(new Error(`Upstream timeout for ${req.url}`));
             });
 


### PR DESCRIPTION

1. Timeout parameter wasn't used previously.
2. `proxyReq.destroy();` will make sure that if socket has timed out it will be closed completely. This will prevent tcp_mem leak due to stale sockets in established state. Node doesn't handle this automatically.